### PR TITLE
구축 사이트 별 환경 설정을 위한 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ $ git clone https://github.com/openinfradev/decapod-bootstrap
 The repository structure looks as follows.
 ```
 ├── README.md
+├── genereate_yamls.sh
 ├── argocd-install
 │   └── values-override.yaml
 ├── decapod-apps
@@ -33,6 +34,8 @@ The repository structure looks as follows.
     └── decapod-controller.yaml
 ```
 
+* genereate_yamls.sh: create YAML files for bootstrapping if you don't use the default decapod git repository in github.com/openinfradev
+
 Directory contents
 * argocd-install: value-override file for argocd helm chart, which contains configuration to create the following (meta) project and app.
   * meta-project 'decapod-projects'
@@ -41,7 +44,6 @@ Directory contents
 * decapod-projects: directory for actual project manifest files. Once any manifest file is added, it's detected by 'decapod-projects' project, and created as argocd project.
 
 * decapod-apps: directory for actual application manifest files. Once any manifest file is added, it's detected by 'decapod-apps' project, and created as argocd application.
-
 
 ### Create namespaces
 ```

--- a/argocd-install/template-values-override.yaml
+++ b/argocd-install/template-values-override.yaml
@@ -1,0 +1,69 @@
+server:
+  service:
+    type: NodePort
+  extraArgs:
+    - --insecure
+  configEnabled: true
+  config:
+    repositories: |
+      - type: git
+        url: ${DECAPOD_BOOTSTRAP_GIT_REPO_URL}
+  additionalApplications:
+    - name: decapod-apps
+      namespace: argo
+      destination:
+        namespace: argo
+        server: https://kubernetes.default.svc
+      project: decapod-bootstrap
+      source:
+        path: decapod-apps
+        repoURL: ${DECAPOD_BOOTSTRAP_GIT_REPO_URL}
+        targetRevision: HEAD
+        directory:
+          recurse: true
+          jsonnet: {}
+      syncPolicy:
+        automated:
+          selfHeal: true
+          prune: true
+    - name: decapod-projects
+      namespace: argo
+      destination:
+        namespace: argo
+        server: https://kubernetes.default.svc
+      project: decapod-bootstrap
+      source:
+        path: decapod-projects
+        repoURL: ${DECAPOD_BOOTSTRAP_GIT_REPO_URL}
+        targetRevision: HEAD
+        directory:
+          recurse: true
+          jsonnet: {}
+      syncPolicy:
+        automated:
+          selfHeal: true
+          prune: true
+  additionalProjects:
+  - name: decapod-bootstrap
+    namespace: argo
+    additionalLabels: {}
+    additionalAnnotations: {}
+    description: Project for decapod-bootstrap
+    sourceRepos:
+    - '*'
+    destinations:
+    - namespace: argo
+      server: https://kubernetes.default.svc
+    - namespace: decapod-db
+      server: https://kubernetes.default.svc
+    clusterResourceWhitelist:
+    - group: '*'
+      kind: '*'
+    orphanedResources:
+      warn: false
+  metrics:
+    enabled: true
+dex.metrics.enabled: true
+controller.metrics.enabled: true
+repoServer.metrics.enabled: true
+redis-ha.haproxy.metrics.enabled: false

--- a/argocd-install/values-override.yaml
+++ b/argocd-install/values-override.yaml
@@ -8,9 +8,6 @@ server:
     repositories: |
       - type: git
         url: https://github.com/openinfradev/decapod-bootstrap.git
-      - name: argo-helm
-        type: helm
-        url: https://argoproj.github.io/argo-helm
   additionalApplications:
     - name: decapod-apps
       namespace: argo

--- a/decapod-apps/template-argo-workflows.yaml
+++ b/decapod-apps/template-argo-workflows.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: argo-workflows
+  namespace: argo
+spec:
+  destination:
+    namespace: argo
+    server: https://kubernetes.default.svc
+  project: decapod-controller
+  source:
+    path: ${DECAPOD_SITE_NAME}/decapod-controller/argo-workflows-operator
+    repoURL: ${DECAPOD_MANIFESTS_GIT_REPO_URL}
+    targetRevision: HEAD
+  syncPolicy:
+    syncOptions:
+    - CreateNamespace=false
+    automated:
+      selfHeal: true
+      prune: true

--- a/decapod-apps/template-db-secret-argo.yaml
+++ b/decapod-apps/template-db-secret-argo.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: db-secret-argo
+  namespace: argo
+spec:
+  destination:
+    namespace: argo
+    server: https://kubernetes.default.svc
+  project: decapod-controller
+  source:
+    path: ${DECAPOD_SITE_NAME}/decapod-controller/db-secret-argo
+    repoURL: ${DECAPOD_MANIFESTS_GIT_REPO_URL}
+    targetRevision: HEAD
+  syncPolicy:
+    syncOptions:
+    - CreateNamespace=false
+    automated:
+      selfHeal: true
+      prune: true

--- a/decapod-apps/template-db-secret-decapod-db.yaml
+++ b/decapod-apps/template-db-secret-decapod-db.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: db-secret-decapod-db
+  namespace: argo
+spec:
+  destination:
+    namespace: decapod-db
+    server: https://kubernetes.default.svc
+  project: decapod-controller
+  source:
+    path: ${DECAPOD_SITE_NAME}/decapod-controller/db-secret-decapod-db
+    repoURL: ${DECAPOD_MANIFESTS_GIT_REPO_URL}
+    targetRevision: HEAD
+  syncPolicy:
+    syncOptions:
+    - CreateNamespace=false
+    automated:
+      selfHeal: true
+      prune: true

--- a/decapod-apps/template-postgresql.yaml
+++ b/decapod-apps/template-postgresql.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: postgresql
+  namespace: argo
+spec:
+  destination:
+    namespace: decapod-db
+    server: https://kubernetes.default.svc
+  project: decapod-controller
+  source:
+    path: ${DECAPOD_SITE_NAME}/decapod-controller/postgresql
+    repoURL: ${DECAPOD_MANIFESTS_GIT_REPO_URL}
+    targetRevision: HEAD
+  syncPolicy:
+    syncOptions:
+    - CreateNamespace=false
+    automated:
+      selfHeal: true
+      prune: true

--- a/genereate_yamls.sh
+++ b/genereate_yamls.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+set -e
+
+DECAPOD_SITE_NAME="hanu-reference"
+DECAPOD_BOOTSTRAP_GIT_REPO_URL="https://github.com/openinfradev/decapod-bootstrap.git"
+DECAPOD_MANIFESTS_GIT_REPO_URL="https://github.com/openinfradev/decapod-manifests.git"
+
+function usage {
+        echo -e "\nUsage: $0 [--site SITE_NAME] [--bootstrap-git BOOTSTRAP_GIT_URL ] [--manifests-git MANIFESTS_GIT_URL]"
+        exit 1
+}
+
+# We use "$@" instead of $* to preserve argument-boundary information
+ARGS=$(getopt -o 's:b:m:h' --long 'site:,bootstrap-git:,manifests-git:,help' -- "$@") || usage
+eval "set -- $ARGS"
+
+while true; do
+    case $1 in
+      (-h|--help)
+            usage; shift 2;;
+      (-s|--site)
+            DECAPOD_SITE_NAME=$2; shift 2;;
+      (-b|--bootstrap-git)
+            DECAPOD_BOOTSTRAP_GIT_REPO_URL=$2; shift 2;;
+      (-m|--manifests-git)
+            DECAPOD_MANIFESTS_GIT_REPO_URL=$2; shift 2;;
+      (--)  shift; break;;
+      (*)   exit 1;;           # error
+    esac
+done
+
+export DECAPOD_SITE_NAME
+export DECAPOD_BOOTSTRAP_GIT_REPO_URL
+export DECAPOD_MANIFESTS_GIT_REPO_URL
+
+echo "=== Create YAML files using the following Decapod configuration. For help, use the '-h' option"
+echo " Site: "$DECAPOD_SITE_NAME
+echo " Bootstrap Git: "$DECAPOD_BOOTSTRAP_GIT_REPO_URL
+echo " Manifests Git: "$DECAPOD_MANIFESTS_GIT_REPO_URL
+
+DIRS="argocd-install decapod-apps"
+for dir in $DIRS
+do
+	if [[ -z $(ls | grep ${dir}) ]]
+	then
+		echo "execute $0 in decapod-bootstrap directory"
+		exit 1
+	fi
+done
+
+for dir in $DIRS
+do
+	for tpl in $(find ${dir} -name template-* -printf "%f\n")
+	do
+		cat $dir/${tpl} | envsubst > ${dir}/${tpl:9}
+	done
+done


### PR DESCRIPTION
온라인/오프라인, 내부 git 저장소 운영 등 구축 사이트 별 환경에 대응하기 위해 아래 3가지 항목을 설정 가능토록 하고 최종 yaml 파일들을 생성하도록 (genereate_yamls.sh) 수정하였습니다.
- DECAPOD_SITE_NAME="hanu-reference"
- DECAPOD_BOOTSTRAP_GIT_REPO_URL="https://github.com/openinfradev/decapod-bootstrap.git"
- DECAPOD_MANIFESTS_GIT_REPO_URL="https://github.com/openinfradev/decapod-manifests.git"