### PR TITLE
argocd ignore autoscaling nodes

### DIFF
--- a/argocd-install/template-values-override.yaml
+++ b/argocd-install/template-values-override.yaml
@@ -21,6 +21,14 @@ server:
           health_status.status = "Healthy"
           health_status.message = "Jaeger Controlplane is Running"
           return health_status
+      cluster.x-k8s.io/MachinePool:
+        ignoreDifferences: |
+          jsonPointers:
+          - /spec/replicas
+      cluster.x-k8s.io/MachineDeployment:
+        ignoreDifferences: |
+          jsonPointers:
+          - /spec/replicas
     resource.customizations.ignoreDifferences.admissionregistration.k8s.io_MutatingWebhookConfiguration: |
       jqPathExpressions:
       - '.webhooks[]?.clientConfig.caBundle'

--- a/argocd-install/values-override.yaml
+++ b/argocd-install/values-override.yaml
@@ -21,6 +21,14 @@ server:
           health_status.status = "Healthy"
           health_status.message = "Jaeger Controlplane is Running"
           return health_status
+      cluster.x-k8s.io/MachinePool:
+        ignoreDifferences: |
+          jsonPointers:
+          - /spec/replicas
+      cluster.x-k8s.io/MachineDeployment:
+        ignoreDifferences: |
+          jsonPointers:
+          - /spec/replicas
     resource.customizations.ignoreDifferences.admissionregistration.k8s.io_MutatingWebhookConfiguration: |
       jqPathExpressions:
       - '.webhooks[]?.clientConfig.caBundle'
@@ -39,7 +47,7 @@ server:
       source:
         path: decapod-apps
         repoURL: https://github.com/openinfradev/decapod-bootstrap.git
-        targetRevision: release-v2
+        targetRevision: main
         directory:
           recurse: true
           jsonnet: {}
@@ -56,7 +64,7 @@ server:
       source:
         path: decapod-projects
         repoURL: https://github.com/openinfradev/decapod-bootstrap.git
-        targetRevision: release-v2
+        targetRevision: main
         directory:
           recurse: true
           jsonnet: {}

--- a/decapod-apps/argo-workflows-crds.yaml
+++ b/decapod-apps/argo-workflows-crds.yaml
@@ -11,7 +11,7 @@ spec:
   source:
     path: decapod-reference/decapod-controller/argo-workflows-operator-crds
     repoURL: https://github.com/openinfradev/decapod-manifests.git
-    targetRevision: release-v2
+    targetRevision: main
   syncPolicy:
     syncOptions:
     - CreateNamespace=false

--- a/decapod-apps/argo-workflows.yaml
+++ b/decapod-apps/argo-workflows.yaml
@@ -11,7 +11,7 @@ spec:
   source:
     path: decapod-reference/decapod-controller/argo-workflows-operator
     repoURL: https://github.com/openinfradev/decapod-manifests.git
-    targetRevision: release-v2
+    targetRevision: main
   syncPolicy:
     syncOptions:
     - CreateNamespace=false

--- a/decapod-apps/db-secret-argo.yaml
+++ b/decapod-apps/db-secret-argo.yaml
@@ -11,7 +11,7 @@ spec:
   source:
     path: decapod-reference/decapod-controller/db-secret-argo
     repoURL: https://github.com/openinfradev/decapod-manifests.git
-    targetRevision: release-v2
+    targetRevision: main
   syncPolicy:
     syncOptions:
     - CreateNamespace=false

--- a/decapod-apps/db-secret-decapod-db.yaml
+++ b/decapod-apps/db-secret-decapod-db.yaml
@@ -11,7 +11,7 @@ spec:
   source:
     path: decapod-reference/decapod-controller/db-secret-decapod-db
     repoURL: https://github.com/openinfradev/decapod-manifests.git
-    targetRevision: release-v2
+    targetRevision: main
   syncPolicy:
     syncOptions:
     - CreateNamespace=false

--- a/decapod-apps/postgresql.yaml
+++ b/decapod-apps/postgresql.yaml
@@ -11,7 +11,7 @@ spec:
   source:
     path: decapod-reference/decapod-controller/postgresql
     repoURL: https://github.com/openinfradev/decapod-manifests.git
-    targetRevision: release-v2 
+    targetRevision: main
   syncPolicy:
     syncOptions:
     - CreateNamespace=false

--- a/genereate_yamls.sh
+++ b/genereate_yamls.sh
@@ -10,7 +10,7 @@ DOCKER_IMAGE_REPO="docker.io"
 QUAY_IMAGE_REPO="quay.io"
 GITHUB_IMAGE_REPO="ghcr.io"
 
-GIT_REVISION="HEAD"
+GIT_REVISION="main"
 
 function usage {
         echo -e "\nUsage: $0 [--site SITE_NAME] [--bootstrap-git BOOTSTRAP_GIT_URL ] [--manifests-git MANIFESTS_GIT_URL] [--git-rev GIT_REVISION] [--registry REGISTRY_URL]"


### PR DESCRIPTION
TKS에서 기본적으로 cluster-autoscaler를 적용하고 있기 때문에 cluster-api machinedeployment와 machinepool의 replica 스펙이 저장소와 다르더라도 이를 무시하고 out of sync가 상태로 변경되지 않도록 예외 설정을 추가하였습니다. 추가로 기본 리비전 정보를 모두 main으로 통일하였습니다.