### PR TITLE
argocd: add custom health check for prometheus-operator

### DIFF
--- a/argocd-install/template-values-override.yaml
+++ b/argocd-install/template-values-override.yaml
@@ -29,6 +29,12 @@ server:
         ignoreDifferences: |
           jsonPointers:
           - /spec/replicas
+      monitoring.coreos.com/Prometheus:
+        health.lua: |
+          health_status = {}
+          health_status.status = "Healthy"
+          health_status.message = "Prometheus is deployed"
+          return health_status
     resource.customizations.ignoreDifferences.admissionregistration.k8s.io_MutatingWebhookConfiguration: |
       jqPathExpressions:
       - '.webhooks[]?.clientConfig.caBundle'

--- a/argocd-install/values-override.yaml
+++ b/argocd-install/values-override.yaml
@@ -29,6 +29,12 @@ server:
         ignoreDifferences: |
           jsonPointers:
           - /spec/replicas
+      monitoring.coreos.com/Prometheus:
+        health.lua: |
+          health_status = {}
+          health_status.status = "Healthy"
+          health_status.message = "Prometheus is deployed"
+          return health_status
     resource.customizations.ignoreDifferences.admissionregistration.k8s.io_MutatingWebhookConfiguration: |
       jqPathExpressions:
       - '.webhooks[]?.clientConfig.caBundle'


### PR DESCRIPTION
prometheus-opreator의 Prometheus CR 대상으로 custom health check (무조건 "Healthy"로 간주) 를 추가합니다.