### PR TITLE
argocd: add custom health for cluster-api machinedeployment

### DIFF
--- a/argocd-install/template-values-override.yaml
+++ b/argocd-install/template-values-override.yaml
@@ -29,6 +29,19 @@ server:
         ignoreDifferences: |
           jsonPointers:
           - /spec/replicas
+        health.lua: |
+          hs = {}
+          if obj.spec ~= nil and obj.status ~= nil then
+            if obj.spec.replicas == obj.status.replicas then
+              hs.status = "Healthy"
+              hs.message = "All machines targeted by this deployment were created"
+              return hs
+            end
+          end
+
+          hs.status = "Progressing"
+          hs.message = "Waiting for machines for this deployment"
+          return hs
       monitoring.coreos.com/Prometheus:
         health.lua: |
           health_status = {}

--- a/argocd-install/values-override.yaml
+++ b/argocd-install/values-override.yaml
@@ -29,6 +29,19 @@ server:
         ignoreDifferences: |
           jsonPointers:
           - /spec/replicas
+        health.lua: |
+          hs = {}
+          if obj.spec ~= nil and obj.status ~= nil then
+            if obj.spec.replicas == obj.status.replicas then
+              hs.status = "Healthy"
+              hs.message = "All machines targeted by this deployment were created"
+              return hs
+            end
+          end
+
+          hs.status = "Progressing"
+          hs.message = "Waiting for machines for this deployment"
+          return hs
       monitoring.coreos.com/Prometheus:
         health.lua: |
           health_status = {}


### PR DESCRIPTION
Cluster API MachineDeployment 자원은 CNI 배포를 통해 노드가 Ready 상태가 되어야만 AvailableReplicas 수를 업데이트해서 Health 상태로 전환됩니다. 하지만 ArgoCD가 모든 자원이 Health 상태가 아니라면 설치가 완료되지 않고 계속 기다리는 상황이 발생하고 이후 단계 (CNI 설치를 포함한)가 진행되지 않기 때문에 이를 우회하기 위한 커스텀 헬스 체크 부분 (spec과 status replicas 숫자를 비교)을 추가합니다.